### PR TITLE
Add tags for nix run shell commands

### DIFF
--- a/home/tuckershea/common/core/zsh/default.nix
+++ b/home/tuckershea/common/core/zsh/default.nix
@@ -86,7 +86,15 @@
         local command=$1
         shift
         local args=("$@")
-        nix run "nixpkgs#$command" -- "''${args[@]}"
+        nix run "nixpkgs/nixos-24.05#$command" -- "''${args[@]}"
+      }
+
+      # nixpkgs unstable shorthand
+      nu() {
+        local command=$1
+        shift
+        local args=("$@")
+        nix run "nixpkgs/nixos-unstable#$command" -- "''${args[@]}"
       }
     '';
   };


### PR DESCRIPTION
Prefer stable nixpkgs for normal usage, so that we hit the cache more often (this should be paired with an increase in nix store ttl now that I have a better laptop). Also use unstable nixpkgs as a secondary option so that we have a better chance of hitting the nix foundation binary cache.