### PR TITLE
Add GSSAPI/krb5 authentication for SSH

### DIFF
--- a/home/tuckershea/common/optional/ssh/elmira.nix
+++ b/home/tuckershea/common/optional/ssh/elmira.nix
@@ -22,6 +22,11 @@
         user = "tshea";
       };
     };
+
+    extraConfig = lib.mkMerge [
+        "GSSAPIAuthentication yes"
+        "GSSAPIDelegateCredentials yes"
+    ];
   };
 
   home.file.".ssh/.keep".text = "Managed by home-manager";


### PR DESCRIPTION
Enable GSSAPI Authentication so that kerberos can be used for SSH authentication on relevant machines.