### PR TITLE
Lock nixpkgs in system flake registry

### DIFF
--- a/hosts/common/core/default.nix
+++ b/hosts/common/core/default.nix
@@ -8,6 +8,7 @@
     ./locale.nix
     ./nix.nix
     ./openssh.nix
+    ./registry.nix
     ./zsh.nix
   ];
 

--- a/hosts/common/core/registry.nix
+++ b/hosts/common/core/registry.nix
@@ -1,0 +1,9 @@
+{ inputs, ... }:
+{
+  nix.registry = {
+    nixpkgs = {
+      from = { id = "nixpkgs"; type = "indirect"; };
+      flake = inputs.nixpkgs;
+    };
+  };
+}


### PR DESCRIPTION
Typically, nix commands that require a remote flake download the flake registry every time to ensure they get an up-to-date version. This means a delay in running commands with comma or my old shortcuts due to download times (especially with low connectivity). Additionally, if I run a command I expect it to be cached by nix, but if the registry gets updated I have to download nixpkgs and potentially download or rebuild the command. By locking to the system nixpkgs, I can avoid these downloads while still allowing for timely updates when my system pulls lock updates from github.