### PR TITLE
Add cachix substitutors

### DIFF
--- a/hosts/common/core/nix.nix
+++ b/hosts/common/core/nix.nix
@@ -15,6 +15,16 @@ lib.mkMerge [
 
         # Maybe make this darwin-specific?
         extra-platforms = ["x86_64-darwin" "aarch64-darwin"];
+
+        trusted-public-keys = [
+          "hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs="
+          "tuckershea.cachix.org-1:a9DdtLF8DyqAHFV7VHlA7YvasP6wUMHdOygVyks3JGM="
+        ];
+
+        substituters = [
+          "https://cache.nixos.org/"
+          "https://tuckershea.cachix.org"
+        ];
       };
 
       gc = {


### PR DESCRIPTION
Builds are cached on cachix by github actions. By using it as a substitutor (and trusting its public key) we can utilize these caches.

Resolves #55 