### PR TITLE
Always start shell in home directory

### DIFF
--- a/home/tuckershea/common/core/zsh/default.nix
+++ b/home/tuckershea/common/core/zsh/default.nix
@@ -43,6 +43,8 @@
     };
 
     initExtraFirst = ''
+            cd ~
+
             if [[ -r "''${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-''${(%):-%n}.zsh" ]]
       ; then
               source "''${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-''${(%):-%n}.zsh"


### PR DESCRIPTION
Add a `cd ~` to zshrc to ensure that we start in my home directory regardless of where system shell or tmux think I should start.