### PR TITLE
Add Kanata keybinding daemon to darwin systems

### DIFF
--- a/hosts/common/darwin/default.nix
+++ b/hosts/common/darwin/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./font-smoothing.nix
+    ./kanata
     ./keyboard.nix
     ./nix.nix
   ];

--- a/hosts/common/darwin/kanata/default.nix
+++ b/hosts/common/darwin/kanata/default.nix
@@ -1,0 +1,9 @@
+{ outputs, pkgs, ... }:
+{
+  imports = [
+    outputs.darwinModules.kanata
+  ];
+
+  services.kanata.enable = true;
+  services.kanata.config = builtins.readFile ./kanata.kbd;
+}

--- a/hosts/common/darwin/kanata/kanata.kbd
+++ b/hosts/common/darwin/kanata/kanata.kbd
@@ -1,0 +1,41 @@
+;; A config that maps caps lock to esc when tapped and super when held
+
+(defcfg
+  process-unmapped-keys yes
+)
+
+(defsrc
+    esc  f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12
+    lsgt 1    2    3    4    5    6    7    8    9    0    -    =    bspc
+    tab  q    w    e    r    t    y    u    i    o    p    [    ]    \
+    caps a    s    d    f    g    h    j    k    l    ;    '    ret
+    lsft grv  z    x    c    v    b    n    m    ,    .    /    rsft
+    fn   lctl lalt lmet           spc            rmet ralt
+)
+
+(defalias
+    fnl (tap-hold 200 200 fn (layer-toggle fn))
+
+    supr (multi lsft lctl lalt lmet)
+
+    ces (tap-hold 200 200 esc @supr)
+)
+
+(deflayer base
+    esc  brdn brup _    _    _    _    prev pp   next mute vold  volu
+    lsgt 1    2    3    4    5    6    7    8    9    0    -    =    bspc
+    tab  q    w    e    r    t    y    u    i    o    p    [    ]    \
+    @ces a    s    d    f    g    h    j    k    l    ;    '    ret
+    lsft grv  z    x    c    v    b    n    m    ,    .    /    rsft
+    @fnl lctl lalt lmet           spc            rmet ralt
+)
+
+(deflayer fn
+    esc  f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12 
+    _    _    _    _    _    _    _    _    _    _    _    _    _    _
+    _    _    _    _    _    _    _    _    _    _    _    _    _    _
+    _    _    _    _    _    _    _    _    _    _    _    _    _
+    _    _    _    _    _    _    _    _    _    _    _    _    _
+    _    _    _    _              _              _    _
+)
+

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -1,4 +1,5 @@
 {
+  kanata = import ./kanata.nix;
   keep-hostname = import ./keep-hostname.nix;
   touchid = import ./touchid.nix;
 }

--- a/modules/darwin/kanata.nix
+++ b/modules/darwin/kanata.nix
@@ -1,0 +1,53 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.services.kanata;
+in {
+  options = {
+    services.kanata.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to enable the kanata remapping daemon.";
+    };
+
+    services.kanata.package = mkOption {
+      type = types.package;
+      default = pkgs.callPackage ../../pkgs/kanata-darwin.nix {};
+      description = "The kanata package to use.";
+    };
+
+    services.kanata.config = mkOption {
+      type = types.lines;
+      default = "";
+#      example = "alt + shift - r   :   chunkc quit";
+      description = "Config to kanata.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions =
+    [ { assertion = (cfg.config != "");
+        message = "No Kanata configuration passed at config.services.kanata.config";
+      }
+    ];
+
+    launchd.daemons.kanata = 
+    let
+      config_file = pkgs.writeTextFile {
+        name = "kanata.kbd";
+        text = cfg.config;
+      };
+    in {
+      path = [config.environment.systemPath];
+
+      serviceConfig.ProgramArguments =
+        ["${cfg.package}/bin/kanata" "--cfg" "${config_file}"];
+      serviceConfig.KeepAlive = true;
+      serviceConfig.ProcessType = "Interactive";
+    };
+  };
+}

--- a/pkgs/kanata-darwin.nix
+++ b/pkgs/kanata-darwin.nix
@@ -1,0 +1,17 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.stdenv.mkDerivation rec {
+  name = "kanata";
+  version = "v1.7.0-prerelease-1";
+
+  src = pkgs.fetchurl {
+    url = "https://github.com/jtroo/kanata/releases/download/${version}/kanata_macos_arm64";
+    sha256 = "sha256-y3ZD9ygB8SSTVpL9e2MqDfkEocB+J/EYhgUEiGLr3SM=";
+  };
+
+  phases = ["installPhase" "patchPhase"];
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src $out/bin/kanata
+    chmod +x $out/bin/kanata
+  '';
+}


### PR DESCRIPTION
Kanata allows for keyboard and keybind manipulation at the input device level. This makes it suitable for controlling input to all other applications and daemons, for example the shkd hotkey daemon, which requires that any manipulations (such as adding a super key) occur below it in the keyboard stack.

This allows better system-wide keybinds, sets me up for a return to the shkd hotkey daemon as well as yabai, and opens the door for more complex keyboard manipulations in the future.