### PR TITLE
Rebuild on every commit to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,6 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - "**.nix"
-      - "flake.lock"
 
 jobs:
   build:


### PR DESCRIPTION
Previously we only rebuilt on changes to certain files. This has a few issues:

1. The configuration may break on other changes. For example, if we delete an external config file that is referenced by the config, the build should fail, but will never be run.

2. `build` action doesn't run on lock updates. I'm not too sure what is causing this, but this is the main difference between this and my other Renovate setups. I want to make sure it is run for every commit to main.

3. Other changes aren't cached. Changes to sourced configuration files won't be saved to my binary cache by the action unless it is run. This is of minor importance, but it is preferred for each system to be fully cached before updates are deployed, as most are better equipped for network reads than for building their own configuration. The most-updated input is also nixvim, which takes a long time to rebuild documentation when re-locked.