### PR TITLE
Add clamav for passively scanning hosts

### DIFF
--- a/hosts/common/nixos/clamav.nix
+++ b/hosts/common/nixos/clamav.nix
@@ -1,0 +1,6 @@
+{
+  services.clamav = {
+    daemon.enable = true;
+    updater.enable = true;
+  };
+}

--- a/hosts/common/nixos/default.nix
+++ b/hosts/common/nixos/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./auto-upgrade.nix
+    ./clamav.nix
     ./network.nix
     ./nix.nix
     ./no-wait-online.nix # mitigate NetworkManager Wait-Online failure


### PR DESCRIPTION
Pretty simple way to introduce virus scanning, since I can't devote enough attention to the machines for more active policy.

I should figure out how to aggregate clam logs (as well as other system logs) to a central point.