### PR TITLE
Preserve UIDs and GIDs between reboots on ephemeral systems

### DIFF
--- a/hosts/marlon/default.nix
+++ b/hosts/marlon/default.nix
@@ -42,6 +42,7 @@
   
     directories = [
       "/var/log"
+      "/var/lib/nixos"  # preserve uids/gids between reboots
     ];
   };
 }

--- a/hosts/roland/default.nix
+++ b/hosts/roland/default.nix
@@ -40,6 +40,7 @@
   
     directories = [
       "/var/log"
+      "/var/lib/nixos"  # preserve uids/gids between reboots
     ];
   };
 }


### PR DESCRIPTION
On ephemeral systems, users and groups are recreated on each boot. Therefore, adding new users or groups may shuffle UIDs and GIDs and break persisted file permissions.

Persisting /var/lib/nixos is sufficient to preserve UIDs and GIDs between boot.

Resolves #96