### PR TITLE
Automatically renew kerberos tickets

### DIFF
--- a/hosts/elmira/default.nix
+++ b/hosts/elmira/default.nix
@@ -13,6 +13,7 @@
     # optionals here...
 
     outputs.darwinModules.keep-hostname
+    outputs.darwinModules.krb5renew
     outputs.darwinModules.touchid
 
     ../common/users/tuckershea
@@ -42,6 +43,7 @@
   };
 
   services.keep-hostname.enable = true;
+  services.krb5renew.enable = true;
 
   system.stateVersion = 4;
 }

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -1,5 +1,6 @@
 {
   kanata = import ./kanata.nix;
   keep-hostname = import ./keep-hostname.nix;
+  krb5renew = import ./krb5renew.nix;
   touchid = import ./touchid.nix;
 }

--- a/modules/darwin/krb5renew.nix
+++ b/modules/darwin/krb5renew.nix
@@ -1,0 +1,28 @@
+# Restore configured hostname
+#
+# Simple daemon to refresh my Kerberos tickets.
+# In the long term this should probably be replaced
+# by k5start or similar.
+{
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.services.krb5renew;
+in {
+  options.services.krb5renew = {
+    enable = mkEnableOption "krb5renew";
+  };
+
+  config = mkIf cfg.enable {
+    launchd.daemons.tuckershea-krb5renew = {
+      serviceConfig = {
+        Label = "org.tuckershea.krb5renew";
+        StartInterval = 5 * 60; # every 5 minutes
+      };
+
+      command = "kinit -R -c FILE:/Users/tuckershea/krb5-ccache";
+    };
+  };
+}


### PR DESCRIPTION
Refresh refreshable tickets on my user account at a regular interval, so that I can use them for longer before needing to reauthenticate. I do not want to save my credentials as a keytab or in my system keychain, so this is an acceptable substitute.