### PR TITLE
fix: move from auto-optimise-store to nix.optimise

### DIFF
--- a/hosts/common/core/nix.nix
+++ b/hosts/common/core/nix.nix
@@ -8,7 +8,6 @@
 {
   nix = {
     settings = {
-      auto-optimise-store = true;
       experimental-features = ["nix-command" "flakes"];
       warn-dirty = false;
 
@@ -22,6 +21,12 @@
         "https://tuckershea.cachix.org"
       ];
     };
+
+    optimise.automatic = true;
+    # optimise every Monday morning
+    # customized in hosts/common/darwin/nix.nix
+    # and hosts/common/nixos/nix.nix
+
 
     gc = {
       automatic = true;

--- a/hosts/common/darwin/nix.nix
+++ b/hosts/common/darwin/nix.nix
@@ -2,6 +2,12 @@
   nix.settings.extra-platforms = ["x86_64-darwin" "aarch64-darwin"];
   services.nix-daemon.enable = true;
 
+  nix.optimise.interval = [{
+    Hour = 4;
+    Minute = 15;
+    Weekday = 1;
+  }];
+
   nix.gc.interval = [{
     Hour = 3;
     Minute = 15;

--- a/hosts/common/nixos/nix.nix
+++ b/hosts/common/nixos/nix.nix
@@ -1,4 +1,5 @@
 { ... }:
 {
+  nix.optimise.dates = [ "Mon *-*-* 04:15:00" ];
   nix.gc.dates = "Mon *-*-* 03:15:00";
 }


### PR DESCRIPTION
auto-optimise-store is known to cause store corruption on darwin. optimise is a separate incarnation does that not have these issues.