### PR TITLE
fix: let nix manage daemon activation

### DIFF
--- a/modules/darwin/kanata.nix
+++ b/modules/darwin/kanata.nix
@@ -44,8 +44,8 @@ in {
     in {
       path = [config.environment.systemPath];
 
-      serviceConfig.ProgramArguments =
-        ["${cfg.package}/bin/kanata" "--cfg" "${config_file}"];
+      command =
+        "${cfg.package}/bin/kanata --cfg ${config_file}";
       serviceConfig.KeepAlive = true;
       serviceConfig.ProcessType = "Interactive";
     };


### PR DESCRIPTION
When launchd daemons are started, the nix store may not have been mounted yet. Scripts then fail as their executable is not found, and launchd marks them permanently failed.

By using script or command instead of ProgramArguments, nix-darwin will automatically set scripts to wait until the store is mounted before starting, letting them bootstrap correctly.