### PR TITLE
fix: Set FQDN for machine hostnames

### DIFF
--- a/hosts/elmira/default.nix
+++ b/hosts/elmira/default.nix
@@ -45,9 +45,9 @@
     ];
   };
 
-  networking = {
-    hostName = "elmira";
-  };
+  networking.computerName = "elmira";
+  networking.hostName = "elmira.constellation.tuckershea.com";
+  networking.localHostName = "elmira.local";
 
   services.keep-hostname.enable = true;
   services.krb5renew.enable = true;

--- a/hosts/marlon/default.nix
+++ b/hosts/marlon/default.nix
@@ -23,6 +23,7 @@
   ];
 
   networking.hostName = "marlon";
+  networking.domain = "constellation.tuckershea.com";
   networking.hostId = "c8215d44";
 
   system.stateVersion = "23.11";

--- a/hosts/roland/default.nix
+++ b/hosts/roland/default.nix
@@ -20,6 +20,7 @@
   ];
 
   networking.hostName = "roland";
+  networking.domain = "constellation.tuckershea.com";
   networking.hostId = "d310061c";
 
   system.stateVersion = "23.11";

--- a/hosts/vic/default.nix
+++ b/hosts/vic/default.nix
@@ -18,6 +18,7 @@
   ];
 
   networking.hostName = "vic";
+  networking.domain = "constellation.tuckershea.com";
 
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;


### PR DESCRIPTION
Previously we only set local hostnames and left it up to machines to determine or go without a FQDN. Now we assign them an FQDN.