### PR TITLE
fix: set flags correctly for stateful tailscale

### DIFF
--- a/hosts/marlon/default.nix
+++ b/hosts/marlon/default.nix
@@ -43,7 +43,13 @@
     # Note: we don't use extraUpFlags --reset because
     # tailscale up is only re-run when the machine is not connected
     # to the tailnet, not on every configuration change.
+    extraDaemonFlags = [
+      "--statedir=/var/lib/tailscale"
+    ];
     extraSetFlags = [
+      "--webclient=false"
+    ];
+    extraUpFlags = [
       "--accept-dns"
       "--accept-risk=all"
       "--accept-routes"
@@ -54,10 +60,8 @@
       "--hostname=${config.networking.hostName}-${config.networking.hostId}"
       "--shields-up=false"
       "--ssh=false"
-      "--webclient=false"
-    ];
-    extraUpFlags = [
       "--timeout=30s"
+      "--reset"
     ];
   };
 
@@ -74,6 +78,7 @@
     directories = [
       "/var/log"
       "/var/lib/nixos"  # preserve uids/gids between reboots
+      "/var/lib/tailscale"
     ];
   };
 }

--- a/hosts/marlon/secrets.yaml
+++ b/hosts/marlon/secrets.yaml
@@ -1,4 +1,4 @@
-tailscale_key: ENC[AES256_GCM,data:UGHM4QX6h4hmpgP7lwSv0z7/LQ/6+HbpLGbgiGQmTYzn2zHeFScrtHURALl27Leh4AmAQ2EwOJZIUXFAqQ==,iv:6h83b2OOCigN0lEYSG100uYPqNvQjeIHYYBvzHDYKDk=,tag:HpnF2TEy1qjryugRAU9DvQ==,type:str]
+tailscale_key: ENC[AES256_GCM,data:ogSIN9DBVwLH2cgJSfskHnwMe57nzUJ1AeryeGIL/Dn9n8yQsqaVpvH6lTBsWqYa5vRHL+susgxYN0CLQA==,iv:nkeQI77WBQxMiy8qQ2ANr7PLzqo76lSoLIPIBAGdADg=,tag:0n1dcwnnF9uSTLnB9d60Cw==,type:str]
 k3s_token: ENC[AES256_GCM,data:dLYYCBPHd7jMBSA+kL5XDg==,iv:Hw0N2wGgU86YZIfp+R2RXC4mNGfsVw/B1422nSSW8J0=,tag:+jvI5PbHBpXjIYs0OLpK2Q==,type:str]
 terraria_password: ENC[AES256_GCM,data:FwIr3jVrIA3PHw==,iv:gSft6NQNr0t0wvUD6mCv/ozt38NkwJimEuIR+JZ6I0A=,tag:K64SxsQzvSKOw1yYGeGIRQ==,type:str]
 sops:
@@ -25,8 +25,8 @@ sops:
             SCtqWEFRdEI4QjZFNXBtQVVLNmNhMnMKvWDj/WCMTg566t0LBrd2m/MwJW6aXBNW
             KFM56SrgPQM0WOUXWLRZluQ9weDsBYeFyfXeoY/SSjailzPv7L5j9w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-12-22T18:21:02Z"
-    mac: ENC[AES256_GCM,data:FGXiLxPyXdAzmw4kCinVwFeXriFqsN1Ogj4XpBnBydtlN7vOsLOPzhQqa4q3ln3aXvKJZDme8ykb0kxVUsusUPY9bL6t2l7hTcKhFch87aDKpRQwQbO1WadzEUrt6ZLV12fgf1ALOP0j4waIEV5Xn6Y+8kiYizbstiBAsNa4H9A=,iv:N7rjP+nfU5Ytv9S8Scpm8OLt5Yp3Px67LMAue59rycA=,tag:QdGFXkYKkNEywuQBndZBeQ==,type:str]
+    lastmodified: "2024-12-22T22:05:26Z"
+    mac: ENC[AES256_GCM,data:wFdLehLar+d1HRwbvQWrxer8zC5Q+6uVGH/U8LNtSOvWKVSaKA9mv3dI578oz1kfIXC3XLg1aH/BcmSQAFfXgVH+L1qNzsCU7W8ThsV2ZaZh4JeNceuHO/YpzAtuZrq7wf6VsQqrZXsLq2C33eWD2ftfvWA5yS/U7qMpFIkXGNE=,iv:X4DnWNfSqb6Dp/K0oXh4/Z99fvmIoS/Tsen8hT/3jDY=,tag:tPVRCuE8KrZeMJsfcdGj/Q==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.9.2


### PR DESCRIPTION
Stateful tailscale requires a few changes:

* Persist state directory

* Pass necessary flags in "tailscale up" instead of "tailscale set", or else get an error that all non-default arguments must be passed in "tailscale up"

* Pass "reset" to reset all unspecified arguments