### PR TITLE
fix: disable channels

### DIFF
--- a/hosts/common/core/nix.nix
+++ b/hosts/common/core/nix.nix
@@ -47,6 +47,11 @@
         flake = inputs.nixpkgs;
       };
     };
+
+    # Since we are using flakes for most everything,
+    # remove channels to prevent heaps of warnings
+    # on systems without initialized channels
+    channel.enable = false;
   };
 
   nixpkgs = {


### PR DESCRIPTION
On machines that have channels enabled but do not have them properly initialized (such as the recent tuffy machine, but I've had the same problem on my laptop elmira before), running any nix command throws up a lot of warnings.

Since I prefer using new-style nix commands with the local flake registry (as configured in this same file), I can disable channels across the system. This will resolve this warning with no adverse effects.