### PR TITLE
fix: rekey tuffy secrets for tuffy

### DIFF
--- a/hosts/tuffy-oracle-ash-01/secrets.yaml
+++ b/hosts/tuffy-oracle-ash-01/secrets.yaml
@@ -8,20 +8,20 @@ sops:
         - recipient: age1r3gh0cyefzalugcqd3jvnxjzkhv70ph2ag7438vuvk5xlx7rryrs7pvfpe
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhYm1LdFhVUEdZUEtScnpj
-            dlpvM3Q2bGxIWnpsMk9DOVNsRFBmbVVGK0ZVCkNvc1U0QnNWSDhLc0hpOGIvTi9O
-            TUpubjFadGpQRExiSm9LTE5NY3lEMUkKLS0tIG9vZmVZdmxPRFhERFZidDJ5RFAw
-            c3JyT05raTR5TTk2Y1B2R1FvWHJpZGcKnceU8X/7wQuyqrgElTfnscRn6WxmfuR/
-            +TrjGZ8TdcuB1p+OJ8DCASotoeJesibvP24/dsdRqRB4z7iC+hG90g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrYWd0VHFJQmFodDhHYkc2
+            RFQ5L0lGZGZ6M0NMUG02Z1VjK1Y0RzhtK1ZjClhxdXh4MEJBVDBBZzgyT205cEtD
+            emZTQnBQNHFKVFNLa0UxaUZrMm9sQnMKLS0tIDRMZDdFVEcrSjZUOHY3RGVGUVNn
+            dzRsTi8vRTVneHVucDlVRGJWKzRRcWcK9lNVicXnhrYhy9RCExURQA3eC7iyMKUU
+            JgewuuHUHj9ALgJPFASywei4XZKUU1vlIq+5wHM9deBs3eBI41ZLrA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1mxeanghmkfjqjcs8n3vpy952gysrwhmkk7ptrtsxqsuxvsqh83uqnfh0tl
+        - recipient: age1n0z4v6p6epsxhkpwcteglpgwum2z63axpkqkr7jd44dmpewzru2qvzjkkg
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3ZXowUHMyMktuZGJLWExv
-            bnRDSUZvclhCQkowMllpRWZ0c3plOTAxR213Ci8wc04xT3I3cnJsVkVUQXJLTGRq
-            OXdQRFV1RWlIb0tTclg3ODArcGN6em8KLS0tIExwTVdDYjJYamJ3aGhCejZUOXlM
-            SCtqWEFRdEI4QjZFNXBtQVVLNmNhMnMKvWDj/WCMTg566t0LBrd2m/MwJW6aXBNW
-            KFM56SrgPQM0WOUXWLRZluQ9weDsBYeFyfXeoY/SSjailzPv7L5j9w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpNjQ3RU9wOHZIS1RadGEx
+            Y3pwbFBudWJ4MnFzZVdrR3EvbHNBT3BwU0VRCkZ2Zy96RlA3UVo1Z0RaMWRTL0Z1
+            TTcvYlYwOEowQTBDcGpDRzg2WHhhdjAKLS0tIEhPNUJWcVVUSHhiOGxSSFVoYnlU
+            ZFlrYjFvRnloK1FQcGdtV01KTjZsZG8KUl5RjDGGyNf0toQQG1yFRwkyuEoO+iYQ
+            AG3aEIhaGqOVq3PriEZ8kU5ZC6bABoobIOoJHMQ2LIsEVR9cIC+Wlg==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2024-12-24T23:18:24Z"
     mac: ENC[AES256_GCM,data:IrIMaZTGFEZ8wsEfXiLI+xEmfwvWRpcAZKAM97hfnhgdRirVCRUiqjmXgvMGoHfQdKa/SovzkDy0++/KW+trwfULzpFA/xwHYVUwVJmVAuyqUqp09DYMWYkzw7XjtEEqhuvBak4pwumyjl9ezXhxwm53vsiIIIBpOhp3hpR1oUc=,iv:q/t5560ViT8ZNHZk/fvh26Fx6EU5lX9HXwf7jFVVTXI=,tag:ZV/B5YTWQr9wm3JI2fJzUA==,type:str]


### PR DESCRIPTION
`sops` automatically assumes that the keys already present in a file should continue to be used if secrets get updated. This is unintuitive if you update .sops.yaml but do not run `sops updatekeys <file>` on a copied (or rekeyed) file.

On a more secure system, the tuffy keys should be rotated. We choose not to for simplicity.