### PR TITLE
aerospace: float FaceTime by default

### DIFF
--- a/home/tuckershea/graphical/aerospace/aerospace.toml
+++ b/home/tuckershea/graphical/aerospace/aerospace.toml
@@ -65,6 +65,10 @@ outer.right =      0
 3 = 'built-in'
 10 = 'secondary'
 
+[[on-window-detected]]
+    if.app-id = 'com.apple.FaceTime'
+    run = 'layout floating'
+
 # 'main' binding mode declaration
 # See: https://nikitabobko.github.io/AeroSpace/guide#binding-modes
 # 'main' binding mode must be always presented


### PR DESCRIPTION
FaceTime is one of the annoying apps that has strong opinions on its aspect ratio. It tends to become glitchy when Aerospace tries to resize and shuffle it a lot. Floating it will prevent this, much like with Settings.