### PR TITLE
hetzner: initial platform configuration

### DIFF
--- a/hosts/common/nixos/default.nix
+++ b/hosts/common/nixos/default.nix
@@ -1,4 +1,8 @@
 {
+  outputs,
+  ...
+}:
+{
   imports = [
     ./auto-upgrade.nix
     ./cis-hardening.nix
@@ -10,6 +14,8 @@
     ./openssh.nix
     ./sudo-no-password.nix # don't require password for sudo
     ./tailscale.nix
+
+    outputs.nixosModules.hetzner
   ];
 
   # Prefer full NTP for higher-accuracy time

--- a/hosts/marlon/default.nix
+++ b/hosts/marlon/default.nix
@@ -28,6 +28,13 @@
   networking.domain = "constellation.tuckershea.com";
   networking.hostId = "c8215d44";
 
+  platforms.hetzner = {
+    enable = true;
+
+    ipv6.enable = true;
+    ipv6.subnet = "2a01:4f9:c012:aeb7::/64";
+  };
+
   system.stateVersion = "23.11";
 
   users.mutableUsers = false;

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,4 +1,5 @@
 {
+  hetzner = import ./hetzner.nix;
   mailrise = import ./mailrise.nix;
   tailscale-autoconnect = import ./tailscale-autoconnect.nix;
 }

--- a/modules/nixos/hetzner.nix
+++ b/modules/nixos/hetzner.nix
@@ -1,0 +1,55 @@
+{
+   config,
+   lib,
+   pkgs,
+   ...
+}:
+let
+  inherit lib;
+  inherit (lib) types mkEnableOption mkIf mkOption;
+  cfg = config.platforms.hetzner;
+in {
+  options.platforms.hetzner = {
+    enable = mkEnableOption "hetzner";
+
+    ipv6.enable = mkEnableOption "IPv6";
+    ipv6.subnet = mkOption {
+      type = types.str;
+      description = ''
+        IPv6 subnet (usually a /64). Written as an IPv6 address,
+        including the subnet mask.
+      '';
+    };
+  };
+  
+  config = let 
+    # Some default differences between amd64 and arm64 on Hetzner
+    interface = if pkgs.system == "x86_64-linux" then "ens3"
+                                                 else "enp1s0";
+    subaddr   = if pkgs.system == "x86_64-linux" then "1"
+                                                 else "2";
+
+    mkAddress = {subnet, last_octet}: let
+      # this is totally fake
+      # but not sure if nix has real ipv6 handling provisions
+      start = builtins.elemAt (builtins.match "^(.*:)[^:]*" subnet) 0;
+    in
+      "${start}${last_octet}"
+    ;
+    address = mkAddress { inherit (cfg.ipv6) subnet; last_octet = subaddr; };
+    prefixLength = let
+      as_str = builtins.elemAt (builtins.match "^.*/(.*)$" cfg.ipv6.subnet) 0;
+    in lib.strings.toInt as_str;
+  in mkIf cfg.enable {
+    networking.defaultGateway6 = mkIf cfg.ipv6.enable {
+      address = "fe80::1";  # Default for Hetzner
+      inherit interface;
+    };
+    
+    networking.interfaces."${interface}".ipv6.addresses = mkIf cfg.ipv6.enable [
+      {
+        inherit address prefixLength;
+      }
+    ];
+  };
+}


### PR DESCRIPTION
Hetzner needs custom configuration for the network (and potentially other things) going forward. Add a module to configure that.

This needs a once-over on formatting/naming/ipv4? before committing.