### PR TITLE
tmux: reconfigure saving

### DIFF
--- a/home/tuckershea/shell/tmux/default.nix
+++ b/home/tuckershea/shell/tmux/default.nix
@@ -22,9 +22,18 @@
     ];
 
     plugins = with pkgs; [
-      tmuxPlugins.copycat
-      tmuxPlugins.yank
-      tmuxPlugins.resurrect
+      {
+        plugin = tmuxPlugins.resurrect;
+        extraConfig = ''
+          set -g @resurrect-save 'S'
+        '';
+      }
+#       {
+#         plugin = tmuxPlugins.yank;
+#         extraConfig = ''
+#           set -g @yank_action 'copy-pipe'
+#         '';
+#       }
       {
         plugin = tmuxPlugins.continuum;
         extraConfig = ''


### PR DESCRIPTION
leader ctrl-s is by default to save the tmux state with resurrect. since I use ctrl-s as leader, this means that I cannot pass it through to remote machines. Just rebind it.