### PR TITLE
nix: trust garnix cache

### DIFF
--- a/hosts/common/core/nix.nix
+++ b/hosts/common/core/nix.nix
@@ -14,11 +14,13 @@
       trusted-public-keys = [
         "hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs="
         "tuckershea.cachix.org-1:a9DdtLF8DyqAHFV7VHlA7YvasP6wUMHdOygVyks3JGM="
+        "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
       ];
 
       substituters = [
         "https://cache.nixos.org/"
         "https://tuckershea.cachix.org"
+        "https://cache.garnix.io"
       ];
     };
 


### PR DESCRIPTION
Recently I do nix CI via garnix. Since it is much faster than GHA this may mean that configurations are cached sooner.