### PR TITLE
platforms/hetzner: re-enable ipv4

### DIFF
--- a/modules/nixos/hetzner.nix
+++ b/modules/nixos/hetzner.nix
@@ -46,10 +46,13 @@ in {
       inherit interface;
     };
     
-    networking.interfaces."${interface}".ipv6.addresses = mkIf cfg.ipv6.enable [
-      {
-        inherit address prefixLength;
-      }
-    ];
+    networking.interfaces."${interface}" = {
+      useDHCP = true;
+      ipv6.addresses = mkIf cfg.ipv6.enable [
+        {
+          inherit address prefixLength;
+        }
+      ];
+    };
   };
 }


### PR DESCRIPTION
Setting a static configuration for ipv6 seems to disable DHCP for ipv4 (which is enabled by default otherwise). This means that the system is no longer able to access ipv4-only sites for the time being.

Fix this by explicitly enabling DHCP on the physical interface, which will automatically configure ipv4.