### PR TITLE
kernel: prefer swap on zram

### DIFF
--- a/hosts/common/nixos/default.nix
+++ b/hosts/common/nixos/default.nix
@@ -18,6 +18,14 @@
     outputs.nixosModules.hetzner
   ];
 
+  # Really effective way of adding fast swap:
+  # most memory compresses pretty well.
+  zramSwap = {
+    enable = true;
+    algorithm = "zstd";
+    memoryPercent = 100;
+  };
+
   # Prefer full NTP for higher-accuracy time
   services.chrony.enable = true;
 }

--- a/hosts/tuffy-use-ora-01/default.nix
+++ b/hosts/tuffy-use-ora-01/default.nix
@@ -27,12 +27,6 @@
 
   users.mutableUsers = false;
 
-  zramSwap = {
-    enable = true;
-    algorithm = "zstd";
-    memoryPercent = 100;
-  };
-
   environment.persistence."/persist" = {
     hideMounts = true;
     files = [


### PR DESCRIPTION
Swap into compressed pages via zram is now viable. It turns out that memory compresses pretty well, and that spending that CPU time compressing and decompressing is comparable to a write-out to disk in terms of latency.

By default, allow up to 100% memory in ZRAM. Assuming a 2x compression ratio, this results in 50% of memory being taken up by swap for a total of 150%.

This doesn't remove disk swap. I'll consider it!
Especially on the high-RAM machines.