### PR TITLE
misc: speed optimizations

### DIFF
--- a/hosts/marlon/default.nix
+++ b/hosts/marlon/default.nix
@@ -47,6 +47,19 @@
     defaults.renewInterval = "weekly";
   };
 
+  networking.dhcpcd.extraConfig = ''
+    noarp
+    option rapid_commit
+  '';
+
+  boot.blacklistedKernelModules = [
+    "cfg80211"
+    "rfkill"
+    "8021q"
+  ];
+
+  boot.initrd.systemd.enable = true;
+
   environment.persistence."/persist" = {
     hideMounts = true;
     files = [


### PR DESCRIPTION
Using systemd initrd allows for measuring separate kernel/init boot times. It also seems to add a modest speedup.

== DHCP ==

I set noarp on dhcpcd because we don't expect to every be in a situation where we receive an address assigned to another machine.

I also set rapid_commit on dhcpcd because we don't expect multiple DHCP servers.

Probably there is room for improvement by setting static IPs where they are known and not relying on DHCP at all.

== Kernel ==

This is a virtualized server, it doesn't do WIFI. I'm not sure how or why WIFI modules are loading. Blackless cfg80211 and rfkill, because we don't need them.