### PR TITLE
terraria: remove

### DIFF
--- a/hosts/marlon/terraria.nix
+++ b/hosts/marlon/terraria.nix
@@ -1,23 +1,23 @@
 { config, lib, pkgs, ... }:
 {
-  virtualisation.oci-containers.containers.terraria = 
-  let
-    terrariaDockerHub = pkgs.dockerTools.pullImage {
-      imageName = "ryshe/terraria";
-      imageDigest =  # tshock-1.4.4.9-5.2.0-3
-        "sha256:804c42fbe9cbcff0b22c46b120a165ba22b482298e7898ec81803124676d3a0b";
-      sha256 = "sha256-gJ3T+vmEsfIHkA+fUcYZfZnWg0zm9YukCti0fTTLXXA=";
-    };
-  in {
-    hostname = "terraria";
-    image = "ryshe/terraria";
-    imageFile = terrariaDockerHub;
-    ports = [ "7777:7777" ];
-    volumes = [ "/srv/terraria/worlds:/root/.local/share/Terraria/Worlds" ];
-    environment = {
-      WORLD_FILENAME = "World.wld";
-    };
-  };
+#   virtualisation.oci-containers.containers.terraria = 
+#   let
+#     terrariaDockerHub = pkgs.dockerTools.pullImage {
+#       imageName = "ryshe/terraria";
+#       imageDigest =  # tshock-1.4.4.9-5.2.0-3
+#         "sha256:804c42fbe9cbcff0b22c46b120a165ba22b482298e7898ec81803124676d3a0b";
+#       sha256 = "sha256-gJ3T+vmEsfIHkA+fUcYZfZnWg0zm9YukCti0fTTLXXA=";
+#     };
+#   in {
+#     hostname = "terraria";
+#     image = "ryshe/terraria";
+#     imageFile = terrariaDockerHub;
+#     ports = [ "7777:7777" ];
+#     volumes = [ "/srv/terraria/worlds:/root/.local/share/Terraria/Worlds" ];
+#     environment = {
+#       WORLD_FILENAME = "World.wld";
+#     };
+#   };
 
   environment.persistence."/persist" = {
     directories = [


### PR DESCRIPTION
I haven't used the terraria server in a bit. The persistent storage will stick around, so remove the service until I want it again. This results in a modest speedup to boot times.