### PR TITLE
deps: only update once a week

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:base"],
   "lockFileMaintenance": {
     "enabled": true,
-    "extends": ["schedule:daily"]
+    "extends": ["schedule:weekly"]
   },
   "nix": {
     "enabled": true


### PR DESCRIPTION
I'd like to keep dependency PRs manual, but it's overwhelming to see updates every day. Only check once a week instead.

Though in general these updates don't break things (without warning), so maybe at some point I just automerge.