### PR TITLE
nix: reboot on upgrade instead of switch

### DIFF
--- a/hosts/common/nixos/auto-upgrade.nix
+++ b/hosts/common/nixos/auto-upgrade.nix
@@ -2,11 +2,12 @@
   system.autoUpgrade = {
     enable = true;
     flake = "github:tuckershea/constellation";
-    dates = "04:00";
+    operation = "boot";
+    dates = "03:00";
     randomizedDelaySec = "45min";
     allowReboot = true;
     rebootWindow = {
-      lower = "01:00";
+      lower = "02:00";
       upper = "05:00";
     };
   };


### PR DESCRIPTION
This is atomic (unlike switching) and also
means that we'll always be running fresh
after upgrading/ more often in general.