### PR TITLE
tuffy-01: remove forlorn disks

### DIFF
--- a/hosts/tuffy-use-ora-01/disks.nix
+++ b/hosts/tuffy-use-ora-01/disks.nix
@@ -46,23 +46,6 @@
           };
         };
       };
-      big-persist = {
-        type = "disk";
-        device = "/dev/sdb";
-        content = {
-          type = "gpt";
-          partitions = {
-            data = {
-              size = "100%";
-              content = {
-                type = "filesystem";
-                format = "ext4";
-                mountpoint = "/big-persist";
-              };
-            };
-          };
-        };
-      };
     };
     nodev = {
       "/" = {
@@ -113,7 +96,6 @@
   fileSystems = {
     "/boot".neededForBoot = true;
     "/persist".neededForBoot = true;
-    "/big-persist".neededForBoot = true;
     "/nix".neededForBoot = true;
     "/".neededForBoot = true;
     "/tmp".neededForBoot = true;


### PR DESCRIPTION
Apparently this disk didn't qualify for free tier. Therefore the machine fails to mount it and thus
fails to boot. I should look into setting up a
recovery plan rather than relying on reflashing
images if I fail to boot correctly, because remote physical machines and Oracle make this very hard!