### PR TITLE
gate: init

### DIFF
--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,4 +1,5 @@
 {
+  gate = import ./gate.nix;
   hetzner = import ./hetzner.nix;
   mailrise = import ./mailrise.nix;
   tailscale-autoconnect = import ./tailscale-autoconnect.nix;

--- a/modules/nixos/gate.nix
+++ b/modules/nixos/gate.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.services.gate;
+  settingsFormat = pkgs.formats.yaml { };
+  configFile = settingsFormat.generate "config.yaml" cfg.settings;
+in {
+  options = {
+    services.gate.enable = mkEnableOption "Whether to enable the gate server.";
+
+    services.gate.package = mkOption {
+      type = types.package;
+      default = pkgs.gate;
+      description = "The gate package to use.";
+    };
+
+    services.gate.settings = mkOption {
+      type = settingsFormat.type;
+      description = "A file with YAML configuration for gate.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # FIXME hardcoded
+    # it's just annoying to extract this from the bind string
+    networking.firewall.allowedTCPPorts = [25565];
+    
+    systemd.services.gate = {
+      after = ["network-pre.target"];
+      wants = ["network-pre.target"];
+      wantedBy = ["multi-user.target"];
+
+      serviceConfig.Type = "exec";
+      script = "${cfg.package}/bin/gate --config ${configFile}";
+    };
+  };
+}


### PR DESCRIPTION
Add a simple module for the Gate minecraft server proxy. Settings are just directly written to YAML.

https://gate.minekube.com/