### PR TITLE
minecraft-server abtech: enable whitelist

### DIFF
--- a/hosts/tuffy-use-ora-01/minecraft.nix
+++ b/hosts/tuffy-use-ora-01/minecraft.nix
@@ -72,8 +72,10 @@
       motd = "🐻 fly by night sound and light";
 
       max-players = 25;
-      # White list is managed by commands
-      #white-list = true;
+      # White list is managed by commands,
+      # so I need to enable it but not specify
+      # players to whitelist.
+      white-list = true;
 
       level-seed = "2430";
 


### PR DESCRIPTION
I misread the nix-minecraft config. I want to force the whitelist on but manage it on my own with commands. I thought I was supposed to omit the white-list property, but I actually needed to omit the list of whitelisted players.