### PR TITLE
minecraft-server abtech: proxy web map tile requests

### DIFF
--- a/hosts/tuffy-use-ora-01/minecraft.nix
+++ b/hosts/tuffy-use-ora-01/minecraft.nix
@@ -52,6 +52,8 @@
     };
   };
 
+  users.users.nginx.extraGroups = [ "minecraft" ];
+
   services.nginx.enable = true;
   networking.firewall.allowedTCPPorts = [ 80 443 ];
   services.nginx.virtualHosts."mc.abte.ch" = {
@@ -60,6 +62,15 @@
     locations."/" = {
       # hardcoded to dynmap
       proxyPass = "http://127.0.0.1:8123";
+    };
+
+    locations."~ ^/tiles/" = {
+      #root = "/srv/minecraft/abtechminecraft/dynmap/web/tiles";
+      root = "/srv/minecraft/abtechminecraft/dynmap/web";
+      extraConfig = ''
+        expires 0;
+        add_header Cache-Control private;
+      '';
     };
   };
 


### PR DESCRIPTION
The online map loads a bit of code and a whole lot of JPGs. Proxy it through nginx instead, because it offers a substantial performance boost and minimizes server load.

This requires no configuration on the server end!