### PR TITLE
minecraft-server abtech: unpack sqlite library

### DIFF
--- a/hosts/tuffy-use-ora-01/disks.nix
+++ b/hosts/tuffy-use-ora-01/disks.nix
@@ -87,10 +87,7 @@
           "defaults"
           "nodev"
           "nosuid"
-          # Minecraft mods write executables here
-          # e.g. sqlite shared library. This is unfortunate
-          # and I hope to find a way around it.
-#          "noexec"
+          "noexec"
           "mode=1777"
         ];
       };


### PR DESCRIPTION
Distant Horizons uses sqlite-jdbc which needs to load an SQLite library. Normally it would just unpack it into /tmp and then load, it, but this is not possible on my machines because world-writeable areas are noexec. Instead, I have to extract it myself and make it accessible to Distant Horizons.

Things I tried and didn't work:
- PATH
- buildInputs
- org.sqlite.lib.path and org.sqlite.lib.name

It might work to create a new isolated tmpdir and provide that as org.sqlite.tmpdir. I didn't try it.

What eventually worked was setting java.library.path to a directory that does contain the object. I extract it into a directory in the store and provide that.